### PR TITLE
Add desktop navigation to open hamburger panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,18 @@
       <img src="/logo.png" alt="E360 Logo" class="h-16 w-auto" />
     </a>
 
-    <!-- Botón hamburguesa a la derecha -->
-    <button id="menu-toggle" class="absolute right-4 text-3xl hover:text-[#2e527f] transition" aria-label="Abrir menú">
+    <!-- Menú de navegación (visible en escritorio) -->
+    <div class="hidden md:flex gap-6 absolute right-4 items-center">
+      <button class="hover:text-[#7fa1c7] transition" data-section="inicio">Inicio</button>
+      <button class="hover:text-[#7fa1c7] transition" data-section="nosotros">Nosotros</button>
+      <button class="hover:text-[#7fa1c7] transition" data-section="servicios">Servicios</button>
+      <button class="hover:text-[#7fa1c7] transition" data-section="mercado">Mercado y Credenciales</button>
+      <button class="hover:text-[#7fa1c7] transition" data-section="publicaciones">Publicaciones</button>
+      <button class="hover:text-[#7fa1c7] transition" data-section="contacto">Contacto</button>
+    </div>
+
+    <!-- Botón hamburguesa (solo móvil) -->
+    <button id="menu-toggle" class="md:hidden absolute right-4 text-3xl hover:text-[#2e527f] transition" aria-label="Abrir menú">
       ☰
     </button>
 

--- a/js/menuhamburguesa.js
+++ b/js/menuhamburguesa.js
@@ -77,6 +77,7 @@ if (overlay) overlay.addEventListener('click', closeMenu);
 document.querySelectorAll('[data-section]').forEach(btn => {
   btn.addEventListener('click', () => {
     const section = btn.getAttribute('data-section');
+    openMenu();
     loadSubmenu(section);
   });
 });


### PR DESCRIPTION
## Summary
- display navigation items at desktop widths
- keep hamburger icon for small screens
- open the panel when clicking any navigation item

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684c70e154b48325ad6ad56903d84fe7